### PR TITLE
Move from HTTPoison to HTTPotion

### DIFF
--- a/lib/cassette/client/generate_st.ex
+++ b/lib/cassette/client/generate_st.ex
@@ -3,7 +3,8 @@ defmodule Cassette.Client.GenerateSt do
   Generates CAS Service Ticket
   """
 
-  use HTTPoison.Base
+  use HTTPotion.Base
+  use Cassette.Client.UrlEncodedHeaders
 
   alias Cassette.Config
   alias Cassette.Client
@@ -19,10 +20,12 @@ defmodule Cassette.Client.GenerateSt do
   """
   @spec perform(Config.t, String.t, String.t) :: response
   def perform(config = %Config{base_url: base_url}, tgt, service) do
-    case post("#{base_url}/v1/tickets/#{tgt}", {:form, [service: service]}, [], Client.options(config)) do
-      {:ok, %HTTPoison.Response{status_code: 404}} -> {:error, :bad_tgt}
-      {:ok, %HTTPoison.Response{status_code: 200, body: body}} -> {:ok, body}
-      {:ok, %HTTPoison.Response{status_code: status_code, body: body}} -> {:fail, status_code, body}
+    opts = Keyword.merge(Client.options(config), body: "service=" <> URI.encode_www_form(service))
+
+    case post("#{base_url}/v1/tickets/#{tgt}", opts) do
+      %HTTPotion.Response{status_code: 404} -> {:error, :bad_tgt}
+      %HTTPotion.Response{status_code: 200, body: body} -> {:ok, body}
+      %HTTPotion.Response{status_code: status_code, body: body} -> {:fail, status_code, body}
       _ -> {:fail, :unknown}
     end
   end

--- a/lib/cassette/client/generate_tgt.ex
+++ b/lib/cassette/client/generate_tgt.ex
@@ -3,7 +3,8 @@ defmodule Cassette.Client.GenerateTgt do
   Generates CAS Ticket Granting Tickets
   """
 
-  use HTTPoison.Base
+  use HTTPotion.Base
+  use Cassette.Client.UrlEncodedHeaders
 
   alias Cassette.Config
   alias Cassette.Client
@@ -13,20 +14,17 @@ defmodule Cassette.Client.GenerateTgt do
                   | {:fail, pos_integer()}
                   | {:fail, :unknown}
 
-  @spec process_headers([{String.t, String.t}]) :: %{String.t => String.t}
-  defp process_headers(headers), do: Enum.into(headers, %{}, fn{k, v} -> {String.downcase(k), v} end)
-
   @doc """
   Do request to cas service to get a ticket granting tickets from user
   """
   @spec perform(Config.t) :: response
   def perform(config = %Config{username: username, password: password, base_url: base_url}) do
-    form_data = {:form, [username: username, password: password]}
+    form_data = "username=#{URI.encode_www_form(username)}&password=#{URI.encode_www_form(password)}"
 
-    case post("#{base_url}/v1/tickets", form_data, %{accept: "*/*"}, Client.options(config)) do
-      {:ok, %HTTPoison.Response{status_code: 400}} -> {:error, :bad_credentials}
-      {:ok, %HTTPoison.Response{status_code: 201, headers: %{"location" => loc}}} -> {:ok, extract_tgt(base_url, loc)}
-      {:ok, %HTTPoison.Response{status_code: status_code}} -> {:fail, status_code}
+    case post("#{base_url}/v1/tickets", Keyword.merge(Client.options(config), body: form_data, headers: [Accept: "*/*"])) do
+      %HTTPotion.Response{status_code: 400} -> {:error, :bad_credentials}
+      %HTTPotion.Response{status_code: 201, headers: headers} -> {:ok, extract_tgt(base_url, headers[:location])}
+      %HTTPotion.Response{status_code: status_code} -> {:fail, status_code}
       _ -> {:fail, :unknown}
     end
   end

--- a/lib/cassette/client/url_encoded_headers.ex
+++ b/lib/cassette/client/url_encoded_headers.ex
@@ -1,0 +1,18 @@
+defmodule Cassette.Client.UrlEncodedHeaders do
+  @moduledoc """
+  Macros for adding functions that process form/url-encoded requests
+  """
+
+  defmacro __using__(_opts) do
+    quote do
+      @doc """
+      Append required headers for form/url-encoded requests
+      """
+      @spec process_request_headers(Keyword.t) :: Keyword.t
+      def process_request_headers(headers) do
+        Keyword.merge(["Content-Type": "application/x-www-form-urlencoded"],
+                      headers)
+      end
+    end
+  end
+end

--- a/lib/cassette/client/validate_ticket.ex
+++ b/lib/cassette/client/validate_ticket.ex
@@ -3,7 +3,8 @@ defmodule Cassette.Client.ValidateTicket do
   Validates a CAS Service Ticket
   """
 
-  use HTTPoison.Base
+  use HTTPotion.Base
+  use Cassette.Client.UrlEncodedHeaders
 
   alias Cassette.Config
   alias Cassette.Client
@@ -15,8 +16,10 @@ defmodule Cassette.Client.ValidateTicket do
   """
   @spec perform(Config.t, String.t, String.t) :: response
   def perform(config = %Config{base_url: base_url}, ticket, service) do
-    case get("#{base_url}/serviceValidate", [], options([params: [service: service, ticket: ticket]], config)) do
-      {:ok, %HTTPoison.Response{status_code: 200, body: body}} -> {:ok, body}
+    opts = options([query: [service: service, ticket: ticket]], config)
+
+    case get("#{base_url}/serviceValidate", opts) do
+      %HTTPotion.Response{status_code: 200, body: body} -> {:ok, body}
       _ -> {:fail, :unknown}
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Cassette.Mixfile do
   use Mix.Project
 
-  def version, do: "1.3.2"
+  def version, do: "1.4.0"
 
   def project do
     [app: :cassette,
@@ -23,7 +23,7 @@ defmodule Cassette.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger, :httpoison, :exml],
+    [applications: [:logger, :httpotion, :exml],
      mod: {Cassette, []}]
   end
 
@@ -47,7 +47,7 @@ defmodule Cassette.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-     {:httpoison, "~> 0.8"},
+     {:httpotion, "~> 3.0.0"},
      {:exml, "~> 0.1"},
      {:ex_doc, "~> 0.11", only: :dev},
      {:earmark, "~> 1.0", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -11,6 +11,8 @@
   "fake_cas": {:hex, :fake_cas, "1.2.1", "ac31ddc98ac89b64719ec78e2fed2531aef8352eda3a23a445e76e8a2eed7595", [:mix], [{:bypass, "~> 0.1", [hex: :bypass, optional: false]}, {:cowboy, "~> 1.0", [hex: :cowboy, optional: false]}, {:plug, "~> 1.1", [hex: :plug, optional: false]}]},
   "hackney": {:hex, :hackney, "1.7.1", "e238c52c5df3c3b16ce613d3a51c7220a784d734879b1e231c9babd433ac1cb4", [:rebar3], [{:certifi, "1.0.0", [hex: :certifi, optional: false]}, {:idna, "4.0.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, optional: false]}]},
   "httpoison": {:hex, :httpoison, "0.11.1", "d06c571274c0e77b6cc50e548db3fd7779f611fbed6681fd60a331f66c143a0b", [:mix], [{:hackney, "~> 1.7.0", [hex: :hackney, optional: false]}]},
+  "httpotion": {:hex, :httpotion, "3.0.3", "17096ea1a7c0b2df74509e9c15a82b670d66fc4d66e6ef584189f63a9759428d", [:mix], [{:ibrowse, "~> 4.4", [hex: :ibrowse, optional: false]}]},
+  "ibrowse": {:hex, :ibrowse, "4.4.0", "2d923325efe0d2cb09b9c6a047b2835a5eda69d8a47ed6ff8bc03628b764e991", [:rebar3], []},
   "idna": {:hex, :idna, "4.0.0", "10aaa9f79d0b12cf0def53038547855b91144f1bfcc0ec73494f38bb7b9c4961", [:rebar3], []},
   "meck": {:hex, :meck, "0.8.4"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [], []},

--- a/test/cassette/client/generate_st_test.exs
+++ b/test/cassette/client/generate_st_test.exs
@@ -13,7 +13,7 @@ defmodule Cassette.Client.GenerateStTest do
 
   test "perform returns :bad_tgt for a 404 response", %{bypass: bypass, config: config, tgt: tgt, service: service} do
     Bypass.expect bypass, fn conn ->
-      conn |> Plug.Conn.resp(404, "not found")
+      Plug.Conn.resp(conn, 404, "not found")
     end
 
     assert {:error, :bad_tgt} = Cassette.Client.GenerateSt.perform(config, tgt, service)
@@ -21,7 +21,7 @@ defmodule Cassette.Client.GenerateStTest do
 
   test "perform returns {:fail, status_code, body} for other error statuses", %{bypass: bypass, config: config, tgt: tgt, service: service} do
     Bypass.expect bypass, fn conn ->
-      conn |> Plug.Conn.resp(418, "I. am. a. freaking. teapot.")
+      Plug.Conn.resp(conn, 418, "I. am. a. freaking. teapot.")
     end
 
     assert {:fail, 418, "I. am. a. freaking. teapot."} = Cassette.Client.GenerateSt.perform(config, tgt, service)
@@ -43,8 +43,7 @@ defmodule Cassette.Client.GenerateStTest do
       assert "POST" == conn.method
       assert conn.body_params["service"] == service
 
-      conn
-      |> Plug.Conn.resp(200, st)
+      Plug.Conn.resp(conn, 200, st)
     end
 
     assert {:ok, ^st} = Cassette.Client.GenerateSt.perform(config, tgt, service)

--- a/test/cassette/client/validate_ticket_test.exs
+++ b/test/cassette/client/validate_ticket_test.exs
@@ -13,7 +13,7 @@ defmodule Cassette.Client.ValidateTicketTest do
 
   test "perform returns {:fail, :unknown} for not-200 response", %{bypass: bypass, config: config, ticket: ticket, service: service} do
     Bypass.expect bypass, fn conn ->
-      conn |> Plug.Conn.resp(404, "not found")
+      Plug.Conn.resp(conn, 404, "not found")
     end
 
     assert {:fail, :unknown} = Cassette.Client.ValidateTicket.perform(config, ticket, service)
@@ -36,8 +36,7 @@ defmodule Cassette.Client.ValidateTicketTest do
       assert conn.query_params["ticket"] == ticket
       assert conn.query_params["service"] == service
 
-      conn
-      |> Plug.Conn.resp(200, body)
+      Plug.Conn.resp(conn, 200, body)
     end
 
     assert {:ok, ^body} = Cassette.Client.ValidateTicket.perform(config, ticket, service)


### PR DESCRIPTION
Hackney (the base for HTTPoison) is having problems
validating certificates with intermediary chains like
the ones we use from thawte. Until this is fixed, we are
moving to HTTPotion/ibrowse.