### PR TITLE
Add timeout param to Cassette.st, Cassette.tgt and Cassette.validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## UNRELEASED
+### Added
+- Add `timeout` param to `Cassette.st`, `Cassette.tgt` and `Cassette.validate`
 
 ## [1.4.1] - 2018-05-27
 ### Added

--- a/lib/cassette/server.ex
+++ b/lib/cassette/server.ex
@@ -72,30 +72,30 @@ defmodule Cassette.Server do
   @doc """
   Validates a `ticket` for the given `service`
   """
-  @spec validate(GenServer.server(), String.t(), String.t()) ::
+  @spec validate(GenServer.server(), String.t(), String.t(), timeout()) ::
           {:ok, User.t()}
           | {:error, term}
-  def validate(server, ticket, service) do
-    GenServer.call(server, {:validate, ticket, service, time_now()})
+  def validate(server, ticket, service, timeout \\ 5000) do
+    GenServer.call(server, {:validate, ticket, service, time_now()}, timeout)
   end
 
   @doc """
   Generates a Ticket Granting Ticket based on the configuration of the `server`
   """
-  @spec tgt(GenServer.server()) :: {:ok, String.t()} | {:error, term}
-  def tgt(server) do
-    GenServer.call(server, {:tgt, time_now()})
+  @spec tgt(GenServer.server(), timeout()) :: {:ok, String.t()} | {:error, term}
+  def tgt(server, timeout \\ 5000) do
+    GenServer.call(server, {:tgt, time_now()}, timeout)
   end
 
   @doc """
   Generates Service Ticket based on the configuration of the `server` and the
   given `tgt`
   """
-  @spec st(GenServer.server(), String.t(), String.t()) ::
+  @spec st(GenServer.server(), String.t(), String.t(), timeout()) ::
           {:ok, String.t()}
           | {:error, term}
-  def st(server, current_tgt, service) do
-    GenServer.call(server, {:st, current_tgt, service, time_now()})
+  def st(server, current_tgt, service, timeout \\ 5000) do
+    GenServer.call(server, {:st, current_tgt, service, time_now()}, timeout)
   end
 
   @doc """

--- a/lib/cassette/support.ex
+++ b/lib/cassette/support.ex
@@ -134,9 +134,9 @@ defmodule Cassette.Support do
       @doc """
       Generates a Ticket Granting Ticket
       """
-      @spec tgt :: {:ok, String.t()} | {:error, term}
-      def tgt do
-        Server.tgt(@name)
+      @spec tgt(timeout()) :: {:ok, String.t()} | {:error, term}
+      def tgt(timeout \\ 5000) do
+        Server.tgt(@name, timeout)
       end
 
       @doc """
@@ -144,14 +144,14 @@ defmodule Cassette.Support do
 
       This function retries once when the TGT is expired on the server side.
       """
-      @spec st(String.t()) :: {:ok, String.t()} | {:error, term}
-      def st(service) do
+      @spec st(String.t(), timeout()) :: {:ok, String.t()} | {:error, term}
+      def st(service, timeout \\ 5000) do
         {:ok, current_tgt} = tgt()
 
-        case Server.st(@name, current_tgt, service) do
+        case Server.st(@name, current_tgt, service, timeout) do
           {:error, :tgt_expired} ->
             {:ok, new_tgt} = tgt()
-            Server.st(@name, new_tgt, service)
+            Server.st(@name, new_tgt, service, timeout)
 
           reply ->
             reply
@@ -162,9 +162,9 @@ defmodule Cassette.Support do
       Validates a given `ticket` against the given `service` or the service set
       in the configuration
       """
-      @spec validate(String.t(), String.t()) :: {:ok, User.t()} | {:error, term}
-      def validate(ticket, service \\ config().service) do
-        Server.validate(@name, ticket, service)
+      @spec validate(String.t(), String.t(), timeout()) :: {:ok, User.t()} | {:error, term}
+      def validate(ticket, service \\ config().service, timeout \\ 5000) do
+        Server.validate(@name, ticket, service, timeout)
       end
 
       @doc false

--- a/test/cassette/server_integration_test.exs
+++ b/test/cassette/server_integration_test.exs
@@ -48,6 +48,14 @@ defmodule Cassette.ServerIntegrationTest do
     assert {:ok, ^st} = Server.st(pid, FakeCas.valid_tgt, "service")
   end
 
+  test "generates a st from the tgt (with timeout)", %{pid: pid} do
+    st = FakeCas.valid_st()
+    {:ok, tgt} = Server.tgt(pid, 6000)
+    ^tgt = FakeCas.valid_tgt()
+
+    assert {:ok, ^st} = Server.st(pid, FakeCas.valid_tgt(), "service", 6000)
+  end
+
   test "generates a st from the tgt (with cache)", %{pid: pid} do
     st = FakeCas.valid_st
     {:ok, tgt} = Server.tgt(pid)
@@ -62,6 +70,13 @@ defmodule Cassette.ServerIntegrationTest do
 
     assert {:ok, %Cassette.User{login: "example"}} =
       Server.validate(pid, FakeCas.valid_st, config.service)
+  end
+
+  test "validates a st (with timeout)", %{pid: pid, config: config} do
+    {:ok, _} = Server.tgt(pid, 6000)
+
+    assert {:ok, %Cassette.User{login: "example"}} =
+      Server.validate(pid, FakeCas.valid_st(), config.service(), 6000)
   end
 
   test "validates a st (with cache)", %{pid: pid, config: config} do


### PR DESCRIPTION
Hello,

I added `timeout` param to functions `Cassette.st`, `Cassette.tgt` and `Cassette.validate` because sometimes our requests for the CAS may take more than 5s (default GenServer.call timeout).

What do you think?

@rhruiz 