### PR TITLE
fix: Added timeout param to Cassette.st when tgt is expired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [UNRELEASED]
+### Fixed
+- Added `timeout` param to `Cassette.st` when `tgt` is expired
+
 ### Added
 - Automatically expire validations with `Process.send_after/3`
 

--- a/lib/cassette/support.ex
+++ b/lib/cassette/support.ex
@@ -146,11 +146,11 @@ defmodule Cassette.Support do
       """
       @spec st(String.t(), timeout()) :: {:ok, String.t()} | {:error, term}
       def st(service, timeout \\ 5000) do
-        {:ok, current_tgt} = tgt()
+        {:ok, current_tgt} = tgt(timeout)
 
         case Server.st(@name, current_tgt, service, timeout) do
           {:error, :tgt_expired} ->
-            {:ok, new_tgt} = tgt()
+            {:ok, new_tgt} = tgt(timeout)
             Server.st(@name, new_tgt, service, timeout)
 
           reply ->


### PR DESCRIPTION
Hey!

I added a timeout parameter to `Cassette.st` function when a `tgt` ticket was expired. This parameter was not being passed before, so every request was generating a tgt with a timeout default value of 5 seconds.

What do you think?

@rhruiz