### PR TITLE
fix: Added handle_info as a catch-all clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [UNRELEASED]
+### Fixed
+- Added `handle_info` as a `catch-all` clause that discards any unknown message.
 
 ## [1.5.1] = 2021-04-15
 ### Fixed

--- a/lib/cassette/server.ex
+++ b/lib/cassette/server.ex
@@ -15,6 +15,7 @@ defmodule Cassette.Server do
   alias Cassette.User
 
   require Cassette.Version
+  require Logger
 
   @typep tgt_request :: {:tgt, non_neg_integer()}
 
@@ -202,6 +203,11 @@ defmodule Cassette.Server do
 
   def handle_info({:expire, :validation, key}, state) do
     state = State.delete_validation(state, key)
+    {:noreply, state}
+  end
+
+  def handle_info(msg, state) do
+    Logger.error("Unexpected message: #{inspect(msg)}")
     {:noreply, state}
   end
 


### PR DESCRIPTION
Hey!

I added a `handle_info` as a `catch-all` clause that discards any unknown messages, and also implemented a logger error.

What do you think?

@rhruiz 